### PR TITLE
Authenticate API requests using access tokens

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           HAS_CHANGES="false"
           
-          if [ "$(git diff-files --quiet)" ] || [ "$(git ls-files --exclude-standard --others)" ]; then
+          if [ ! -z "$(git status -s)" ]; then
             HAS_CHANGES="true"
             echo "Detected changes"
           fi

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           HAS_CHANGES="false"
           
-          if [ ! -z "$(git status -s)" ]; then
+          if [ "$(git status -s)" ]; then
             HAS_CHANGES="true"
             echo "Detected changes"
           fi

--- a/.github/workflows/pr-generate-api-report.yml
+++ b/.github/workflows/pr-generate-api-report.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           HAS_CHANGES="false"
           
-          if [ "$(git diff-files --quiet)" ] || [ "$(git ls-files --exclude-standard --others)" ]; then
+          if [ ! -z "$(git status -s)" ]; then
             HAS_CHANGES="true"
             echo "Detected changes"
           fi

--- a/.github/workflows/pr-generate-api-report.yml
+++ b/.github/workflows/pr-generate-api-report.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           HAS_CHANGES="false"
           
-          if [ ! -z "$(git status -s)" ]; then
+          if [ "$(git status -s)" ]; then
             HAS_CHANGES="true"
             echo "Detected changes"
           fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Node.js library for the OneSpan Sign API
 
+If you wish to contribute to this project, please read the [contribution guidelines](./CONTRIBUTING.md).
+
+## API Documentation
+
+You can view the latest documentation [here](./docs/index.md).
+
 ## Feature Support
 
 ### Packages (Transactions)
@@ -34,10 +40,6 @@ Node.js library for the OneSpan Sign API
 | `/api/packages/{packageId}/documents/{documentId}/pages/{index}` | :x:   | -                  | -     | -        |
 
 Any other resources not mentioned in this document are currently **unsupported**.
-
-## API Documentation
-
-You can view the latest documentation [here](./docs/index.md).
 
 ## Tests
 

--- a/etc/onespan-sign-node.api.md
+++ b/etc/onespan-sign-node.api.md
@@ -11,20 +11,50 @@ import { Readable } from 'node:stream';
 import { RequestInit as RequestInit_2 } from 'node-fetch';
 import { Response as Response_2 } from 'node-fetch';
 
+// @public
+export interface AccessTokenOwnerConfig {
+    // (undocumented)
+    clientId: string;
+    // (undocumented)
+    secret: string;
+    // (undocumented)
+    type: 'OWNER';
+}
+
+// @public
+export interface AccessTokenSenderConfig {
+    // (undocumented)
+    clientId: string;
+    // (undocumented)
+    email: string;
+    // (undocumented)
+    secret: string;
+    // (undocumented)
+    type: 'SENDER';
+}
+
 // @alpha (undocumented)
 export type Address = {};
 
 // @public
 export class Api {
-    constructor(apiKey: string, apiUrl: string);
+    constructor(accessTokenConfig: AccessTokenOwnerConfig | AccessTokenSenderConfig, apiUrl: string);
     // (undocumented)
-    protected readonly apiKey: string;
+    protected accessToken?: string;
+    // (undocumented)
+    protected readonly accessTokenConfig: AccessTokenOwnerConfig | AccessTokenSenderConfig;
     // (undocumented)
     protected readonly apiUrl: string;
     delete(url: string): DeleteRequestBuilder;
     get(url: string): GetRequestBuilder;
+    // @internal
+    protected getAuthorizationHeader(): Promise<string>;
+    // @internal
+    protected isAccessTokenInvalid(): boolean;
     post(url: string): PostRequestBuilder;
     put(url: string): PostRequestBuilder;
+    // (undocumented)
+    protected tokenExpiry?: number;
 }
 
 // @public (undocumented)
@@ -313,7 +343,7 @@ export type Nullable<T> = T | null;
 
 // @public
 export class OneSpanSign {
-    constructor(apiKey: string, apiUrl: string);
+    constructor(accessTokenConfig: AccessTokenOwnerConfig | AccessTokenSenderConfig, apiUrl: string);
     // (undocumented)
     protected api: Api;
     get documents(): DocumentResource;

--- a/src/OneSpanSign.ts
+++ b/src/OneSpanSign.ts
@@ -1,5 +1,6 @@
 import { Api } from './api';
 import { DocumentResource, PackageResource } from './resources';
+import { AccessTokenOwnerConfig, AccessTokenSenderConfig } from './types';
 
 /**
  * Main class to interact with OneSpan Sign's API. This class is a
@@ -12,16 +13,17 @@ export class OneSpanSign {
   /**
    * Constructs an instance of the `OneSpanSign` class.
    *
-   * @param apiKey - API key to interact with OneSpan Sign's API
-   * @param apiUrl - Url for the OneSpan Sign API server
+   * @param accessTokenConfig - Configuration to retrieve access tokens to authenticate API requests.
+   * @param apiUrl - Url for the OneSpan Sign API server.
    *
    * @remarks
-   * - For information on how to retrieve your API key, see {@link https://community.onespan.com/documentation/onespan-sign/guides/admin-guides/user/integration | Integration (OneSpan)}.
+   * - For information on how to create a Client App and retrieve the ID and secret,
+   *   see {@link https://community.onespan.com/documentation/onespan-sign/guides/admin-guides/user/integration | Integration (OneSpan)}.
    *
    * - A list of server URLs can be found at {@link https://community.onespan.com/documentation/onespan-sign/guides/quick-start-guides/developer/environment-urls-ip-addresses | Environment URLs & IP Addresses (OneSpan)}.
    */
-  constructor(apiKey: string, apiUrl: string) {
-    this.api = new Api(apiKey, apiUrl);
+  constructor(accessTokenConfig: AccessTokenOwnerConfig | AccessTokenSenderConfig, apiUrl: string) {
+    this.api = new Api(accessTokenConfig, apiUrl);
   }
 
   /**

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -30,8 +30,12 @@ export class Api {
     protected readonly apiUrl: string
   ) {}
 
+  protected isAccessTokenInvalid(): boolean {
+    return !this.accessToken || !this.tokenExpiry || this.tokenExpiry >= Date.now();
+  }
+
   protected async getAuthorizationHeader(): Promise<string> {
-    if (!this.accessToken || !this.tokenExpiry || this.tokenExpiry >= Date.now()) {
+    if (this.isAccessTokenInvalid()) {
       const request = new PostRequestBuilder(new URL('/apitoken/clientApp/accessToken', this.apiUrl))
         .withBody(this.accessTokenConfig)
         .fetch();

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -30,10 +30,27 @@ export class Api {
     protected readonly apiUrl: string
   ) {}
 
+  /**
+   * Helper function to determine if the currently stored access token is invalid.
+   * An invalid access token is either undefined or expired.
+   *
+   * @internal
+   */
   protected isAccessTokenInvalid(): boolean {
     return !this.accessToken || !this.tokenExpiry || this.tokenExpiry >= Date.now();
   }
 
+  /**
+   * Helper function to return the proper Authorization header for a request.
+   *
+   * If the access token is {@link isAccessTokenInvalid | invalid}, it'll attempt to
+   * fetch a new token from OneSpan's access token endpoint.
+   *
+   * @remarks
+   * See {@link https://www.onespan.com/blog/onespan-sign-release-1134-api-token-client-application | API Token for Client Application (OneSpan)}.
+   *
+   * @internal
+   */
   protected async getAuthorizationHeader(): Promise<string> {
     if (this.isAccessTokenInvalid()) {
       const request = new PostRequestBuilder(new URL('/apitoken/clientApp/accessToken', this.apiUrl))

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -74,7 +74,9 @@ export class Api {
    * @public
    */
   public get(url: string): GetRequestBuilder {
-    return new GetRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(this.getAuthorizationHeader);
+    return new GetRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(
+      this.getAuthorizationHeader.bind(this)
+    );
   }
 
   /**
@@ -85,7 +87,9 @@ export class Api {
    * @public
    */
   public post(url: string): PostRequestBuilder {
-    return new PostRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(this.getAuthorizationHeader);
+    return new PostRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(
+      this.getAuthorizationHeader.bind(this)
+    );
   }
 
   /**
@@ -96,7 +100,9 @@ export class Api {
    * @public
    */
   public put(url: string): PostRequestBuilder {
-    return new PutRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(this.getAuthorizationHeader);
+    return new PutRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(
+      this.getAuthorizationHeader.bind(this)
+    );
   }
 
   /**
@@ -107,6 +113,8 @@ export class Api {
    * @public
    */
   public delete(url: string): DeleteRequestBuilder {
-    return new DeleteRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(this.getAuthorizationHeader);
+    return new DeleteRequestBuilder(new URL(url, this.apiUrl)).withAuthorizationHeader(
+      this.getAuthorizationHeader.bind(this)
+    );
   }
 }

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -37,7 +37,7 @@ export class Api {
    * @internal
    */
   protected isAccessTokenInvalid(): boolean {
-    return !this.accessToken || !this.tokenExpiry || this.tokenExpiry >= Date.now();
+    return !this.accessToken || !this.tokenExpiry || this.tokenExpiry <= Date.now();
   }
 
   /**

--- a/src/api/requestBuilders/BaseRequestBuilder.ts
+++ b/src/api/requestBuilders/BaseRequestBuilder.ts
@@ -25,14 +25,38 @@ export class BaseRequestBuilder {
     };
   }
 
+  /**
+   * Sets the `Authorization` header of the request.
+   * @param value - A static string value for the header
+   *
+   * @public
+   */
   public withAuthorizationHeader(value: string): this;
+  /**
+   * Sets the `Authorization` header of the request.
+   * @param value - A callback that returns the value for the header
+   *
+   * @public
+   */
   public withAuthorizationHeader(value: () => string): this;
+  /**
+   * Sets the `Authorization` header of the request.
+   * @param value - A callback that returns the value for the header
+   *
+   * @public
+   */
   public withAuthorizationHeader(value: () => Promise<string>): this;
   public withAuthorizationHeader(value: string | (() => string) | (() => Promise<string>)): this {
     this.requestHeaders.authorization = value;
     return this;
   }
 
+  /**
+   * Sets the `Accept` header of the request.
+   * @param value - A static string value for the header
+   *
+   * @public
+   */
   public withAcceptHeader(value: string): this {
     this.requestHeaders.accept = value;
     return this;
@@ -61,6 +85,10 @@ export class BaseRequestBuilder {
     return this;
   }
 
+  /**
+   * Constructs the header dictionary for the request.
+   * @internal
+   */
   protected async createHeaders(): Promise<Record<string, string>> {
     const { authorization, ...headers } = this.requestHeaders;
 
@@ -75,11 +103,24 @@ export class BaseRequestBuilder {
     return headers;
   }
 
+  /**
+   * Handles the response of the HTTP request by throwing an appropriate error
+   * or return the response as-is if the request is successful.
+   *
+   * @param response - `node-fetch` Response object returned after making the
+   *                    configured request.
+   *
+   * @internal
+   */
   protected handleResponse(response: Response): Response {
     if (response.ok) return response;
     throw new HttpResponseError(response);
   }
 
+  /**
+   * Initiates the configured request.
+   * @public
+   */
   public async fetch(): Promise<Response> {
     const response = await fetch(this.url, {
       ...this.requestOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
  *   clientId: CLIENT_ID,
  *   secret: CLIENT_SECRET,
  *   type: 'OWNER',   // or 'SENDER'
- * });
+ * }, API_URL);
  *
  * const { id: packageId } = await oneSpanSign.packages.create({...});
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@
  *
  * @example
  * ```ts
- * const oneSpanSign = new OneSpanSign(API_KEY, API_URL);
+ * const oneSpanSign = new OneSpanSign({
+ *   clientId: CLIENT_ID,
+ *   secret: CLIENT_SECRET,
+ *   type: 'OWNER',   // or 'SENDER'
+ * });
  *
  * const { id: packageId } = await oneSpanSign.packages.create({...});
  *

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,30 @@
+/**
+ * Configuration to retrieve the access token for a user with
+ * the `OWNER` type.
+ *
+ * @remarks
+ * - {@link https://www.onespan.com/blog/onespan-sign-release-1134-api-token-client-application | API token for Client Application}
+ *
+ * @public
+ */
+export interface AccessTokenOwnerConfig {
+  clientId: string;
+  secret: string;
+  type: 'OWNER';
+}
+
+/**
+ * Configuration to retrieve the access token for a user with
+ * the `SENDER` type.
+ *
+ * @remarks
+ * - {@link https://www.onespan.com/blog/onespan-sign-release-1134-api-token-client-application | API token for Client Application}
+ *
+ * @public
+ */
+export interface AccessTokenSenderConfig {
+  clientId: string;
+  secret: string;
+  type: 'SENDER';
+  email: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 import * as Requests from './requests';
 import * as Responses from './responses';
 
+export * from './api';
 export * from './models';
 export * from './utils';
 export { Requests, Responses };

--- a/tests/OneSpanSign.test.ts
+++ b/tests/OneSpanSign.test.ts
@@ -5,7 +5,14 @@ describe('OneSpanSign', () => {
   let prototype: any;
 
   beforeAll(() => {
-    oneSpanSign = new OneSpanSign('mock-api-key', 'https://demo.com');
+    oneSpanSign = new OneSpanSign(
+      {
+        type: 'OWNER',
+        clientId: 'clientId',
+        secret: 'secret',
+      },
+      'https://demo.com'
+    );
     prototype = Object.getPrototypeOf(oneSpanSign);
   });
 

--- a/tests/api/Api.test.ts
+++ b/tests/api/Api.test.ts
@@ -1,0 +1,62 @@
+import { AccessTokenOwnerConfig, Api } from '../../src';
+import { mockedFetch, mockFetchHappyPath } from '../setup/mockNodeFetch';
+
+const MOCK_TOKEN_CONFIG: AccessTokenOwnerConfig = {
+  type: 'OWNER',
+  clientId: 'clientId',
+  secret: 'secret',
+};
+const MOCK_API_URL = 'http://demo.com';
+
+describe('Api', () => {
+  describe('Authorization header', () => {
+    let api: Api;
+
+    beforeAll(() => {
+      mockFetchHappyPath();
+      api = new Api(MOCK_TOKEN_CONFIG, MOCK_API_URL);
+    });
+
+    afterAll(() => {
+      mockedFetch.mockReset();
+    });
+
+    afterEach(() => {
+      mockedFetch.mockClear();
+    });
+
+    it('attempts to fetch an access token if access token is not yet fetched (undefined)', async () => {
+      await api.get('http://test.com').fetch();
+      expect(mockedFetch.mock.calls.length).toStrictEqual(2);
+      expect(mockedFetch.mock.calls[0]).toMatchSnapshot();
+    });
+
+    it('does not fetch an access token if the token is defined and not expired', async () => {
+      Object.defineProperty(api, 'accessToken', {
+        value: 'token',
+      });
+      Object.defineProperty(api, 'tokenExpiry', {
+        value: Date.now() + 1,
+      });
+
+      await api.get('http://test.com').fetch();
+      expect(mockedFetch.mock.calls.length).toStrictEqual(1);
+    });
+
+    it.each`
+      tokenExpiryGetter
+      ${() => Date.now()}
+      ${() => Date.now() - 1}
+    `('attempts to fetch an access token if access token is expired', async ({ tokenExpiryGetter }) => {
+      Object.defineProperty(api, 'accessToken', {
+        value: 'token',
+      });
+      Object.defineProperty(api, 'tokenExpiry', {
+        value: tokenExpiryGetter(),
+      });
+
+      await api.get('http://test.com').fetch();
+      expect(mockedFetch.mock.calls.length).toStrictEqual(2);
+    });
+  });
+});

--- a/tests/api/Api.test.ts
+++ b/tests/api/Api.test.ts
@@ -26,7 +26,7 @@ describe('Api', () => {
     });
 
     it('attempts to fetch an access token if access token is not yet fetched (undefined)', async () => {
-      await api.get('http://test.com').fetch();
+      await api.get('/test').fetch();
       expect(mockedFetch.mock.calls.length).toStrictEqual(2);
       expect(mockedFetch.mock.calls[0]).toMatchSnapshot();
     });
@@ -36,11 +36,12 @@ describe('Api', () => {
         value: 'token',
       });
       Object.defineProperty(api, 'tokenExpiry', {
-        value: Date.now() + 1,
+        value: Date.now() + 5,
       });
 
-      await api.get('http://test.com').fetch();
+      await api.get('/test').fetch();
       expect(mockedFetch.mock.calls.length).toStrictEqual(1);
+      expect(mockedFetch.mock.calls[0][0]).toStrictEqual(new URL('/test', MOCK_API_URL));
     });
 
     it.each`
@@ -55,8 +56,9 @@ describe('Api', () => {
         value: tokenExpiryGetter(),
       });
 
-      await api.get('http://test.com').fetch();
+      await api.get('/test').fetch();
       expect(mockedFetch.mock.calls.length).toStrictEqual(2);
+      expect(mockedFetch.mock.calls[0]).toMatchSnapshot();
     });
   });
 });

--- a/tests/api/__snapshots__/Api.test.ts.snap
+++ b/tests/api/__snapshots__/Api.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Api Authorization header attempts to fetch an access token if access token is expired 1`] = `
+Array [
+  "http://demo.com/apitoken/clientApp/accessToken",
+  Object {
+    "body": "{\\"type\\":\\"OWNER\\",\\"clientId\\":\\"clientId\\",\\"secret\\":\\"secret\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "content-type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;
+
+exports[`Api Authorization header attempts to fetch an access token if access token is expired 2`] = `
+Array [
+  "http://demo.com/apitoken/clientApp/accessToken",
+  Object {
+    "body": "{\\"type\\":\\"OWNER\\",\\"clientId\\":\\"clientId\\",\\"secret\\":\\"secret\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "content-type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;
+
 exports[`Api Authorization header attempts to fetch an access token if access token is not yet fetched (undefined) 1`] = `
 Array [
   "http://demo.com/apitoken/clientApp/accessToken",

--- a/tests/api/__snapshots__/Api.test.ts.snap
+++ b/tests/api/__snapshots__/Api.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Api Authorization header attempts to fetch an access token if access token is not yet fetched (undefined) 1`] = `
+Array [
+  "http://demo.com/apitoken/clientApp/accessToken",
+  Object {
+    "body": "{\\"type\\":\\"OWNER\\",\\"clientId\\":\\"clientId\\",\\"secret\\":\\"secret\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "content-type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;

--- a/tests/api/requestBuilders/BaseRequestBuilder.test.ts
+++ b/tests/api/requestBuilders/BaseRequestBuilder.test.ts
@@ -1,0 +1,96 @@
+import { BaseRequestBuilder } from '../../../src/api/requestBuilders/BaseRequestBuilder';
+import { mockedFetch, mockFetchHappyPath } from '../../setup/mockNodeFetch';
+
+const MOCK_URL = new URL('/index', 'http://test.com');
+
+describe('BaseRequestBuilder', () => {
+  let requestBuilder: BaseRequestBuilder;
+
+  beforeAll(() => {
+    mockFetchHappyPath();
+  });
+
+  afterAll(() => {
+    mockedFetch.mockReset();
+  });
+
+  beforeEach(() => {
+    requestBuilder = new BaseRequestBuilder(MOCK_URL);
+  });
+
+  afterEach(() => {
+    mockedFetch.mockClear();
+  });
+
+  it('sends and receive JSON objects by default', async () => {
+    await requestBuilder.fetch();
+
+    expect(mockedFetch.mock.calls[0][1]?.headers).toStrictEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+    });
+  });
+
+  describe('withAuthorizationHeader', () => {
+    it('sets Authorization header with the provided string', async () => {
+      await requestBuilder.withAuthorizationHeader('Basic 1234').fetch();
+
+      expect(mockedFetch.mock.calls[0][1]?.headers).toStrictEqual(
+        expect.objectContaining({
+          authorization: 'Basic 1234',
+        })
+      );
+    });
+
+    it('calls the provided callback and set the Authorization header with the returned value', async () => {
+      const headerCallback = jest.fn().mockResolvedValue('Basic 5678');
+
+      await requestBuilder.withAuthorizationHeader(headerCallback).fetch();
+
+      expect(headerCallback).toHaveBeenCalledTimes(1);
+      expect(mockedFetch.mock.calls[0][1]?.headers).toStrictEqual(
+        expect.objectContaining({
+          authorization: 'Basic 5678',
+        })
+      );
+    });
+  });
+
+  describe('withAcceptHeader', () => {
+    it('sets Accept header with the provided string', async () => {
+      await requestBuilder.withAcceptHeader('text/html').fetch();
+
+      expect(mockedFetch.mock.calls[0][1]?.headers).toStrictEqual(
+        expect.objectContaining({
+          accept: 'text/html',
+        })
+      );
+    });
+  });
+
+  describe('withQueryParams', () => {
+    it('appends the provided parameters to the URL of the request', async () => {
+      await requestBuilder
+        .withQueryParams({
+          test: 'true',
+          number: 1,
+        })
+        .fetch();
+
+      expect(mockedFetch.mock.calls[0][0]).toMatchInlineSnapshot(`"http://test.com/index?test=true&number=1"`);
+    });
+
+    it('filters out parameters that are null or undefined', async () => {
+      await requestBuilder
+        .withQueryParams({
+          test: 'true',
+          number: 1,
+          test1: null,
+          test2: undefined,
+        })
+        .fetch();
+
+      expect(mockedFetch.mock.calls[0][0]).toMatchInlineSnapshot(`"http://test.com/index?test=true&number=1"`);
+    });
+  });
+});

--- a/tests/resources/DocumentResource.test.ts
+++ b/tests/resources/DocumentResource.test.ts
@@ -1,20 +1,28 @@
 import { Readable } from 'node:stream';
 
-import { Api, DocumentResource, Requests } from '../../src';
+import { AccessTokenOwnerConfig, Api, DocumentResource, Requests } from '../../src';
+import { mockApiHappyPath, MockedApi, restoreMockedApi } from '../setup/mockApi';
 import { mockedFetch, mockFetchHappyPath } from '../setup/mockNodeFetch';
 
-const MOCK_API_KEY = 'demoKey';
+const MOCK_TOKEN_CONFIG: AccessTokenOwnerConfig = {
+  type: 'OWNER',
+  clientId: 'clientId',
+  secret: 'secret',
+};
 const MOCK_API_URL = 'http://demo.com';
 
 describe('DocumentResource', () => {
+  let mockedApi: MockedApi;
   let documents: DocumentResource;
 
   beforeAll(() => {
     mockFetchHappyPath();
-    documents = new DocumentResource(new Api(MOCK_API_KEY, MOCK_API_URL));
+    mockedApi = mockApiHappyPath();
+    documents = new DocumentResource(new Api(MOCK_TOKEN_CONFIG, MOCK_API_URL));
   });
 
   afterAll(() => {
+    restoreMockedApi(mockedApi);
     mockedFetch.mockReset();
   });
 
@@ -41,7 +49,7 @@ describe('DocumentResource', () => {
       expect(mockedFetch.mock.calls[0][1]).toEqual({
         headers: {
           accept: 'application/json',
-          authorization: `Basic ${MOCK_API_KEY}`,
+          authorization: expect.stringMatching(/^Bearer/),
           'content-type': expect.stringMatching(/^multipart\/form-data; boundary=.+/),
         },
         method: 'POST',

--- a/tests/resources/PackageResource.test.ts
+++ b/tests/resources/PackageResource.test.ts
@@ -1,18 +1,26 @@
-import { PackageResource, Requests, Api } from '../../src';
+import { PackageResource, Requests, Api, AccessTokenOwnerConfig } from '../../src';
+import { mockApiHappyPath, MockedApi, restoreMockedApi } from '../setup/mockApi';
 import { mockedFetch, mockFetchHappyPath } from '../setup/mockNodeFetch';
 
-const MOCK_API_KEY = 'demoKey';
+const MOCK_TOKEN_CONFIG: AccessTokenOwnerConfig = {
+  type: 'OWNER',
+  clientId: 'clientId',
+  secret: 'secret',
+};
 const MOCK_API_URL = 'http://demo.com';
 
 describe('PackageResource', () => {
+  let mockedApi: MockedApi;
   let packages: PackageResource;
 
   beforeAll(() => {
     mockFetchHappyPath();
-    packages = new PackageResource(new Api(MOCK_API_KEY, MOCK_API_URL));
+    mockedApi = mockApiHappyPath();
+    packages = new PackageResource(new Api(MOCK_TOKEN_CONFIG, MOCK_API_URL));
   });
 
   afterAll(() => {
+    restoreMockedApi(mockedApi);
     mockedFetch.mockReset();
   });
 

--- a/tests/resources/__snapshots__/PackageResource.test.ts.snap
+++ b/tests/resources/__snapshots__/PackageResource.test.ts.snap
@@ -7,7 +7,7 @@ Array [
     "body": "{\\"name\\":\\"mock package\\"}",
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "POST",
@@ -21,7 +21,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "DELETE",
@@ -35,7 +35,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -49,7 +49,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -63,7 +63,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -77,7 +77,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -91,7 +91,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/pdf",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -105,7 +105,7 @@ Array [
   Object {
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "GET",
@@ -120,7 +120,7 @@ Array [
     "body": "{\\"name\\":\\"mock package update\\",\\"status\\":\\"ARCHIVED\\"}",
     "headers": Object {
       "accept": "application/json",
-      "authorization": "Basic demoKey",
+      "authorization": "Bearer mockedToken",
       "content-type": "application/json",
     },
     "method": "PUT",

--- a/tests/setup/mockApi.ts
+++ b/tests/setup/mockApi.ts
@@ -1,0 +1,15 @@
+import { Api } from '../../src';
+
+export type MockedApi = jest.SpyInstance[];
+
+export function mockApiHappyPath(): MockedApi {
+  return [jest.spyOn(Api.prototype as any, 'getAuthorizationHeader').mockResolvedValue(`Bearer mockedToken`)];
+}
+
+export function clearMockedApi(mockedApi: MockedApi): void {
+  mockedApi.forEach((mock) => mock.mockClear());
+}
+
+export function restoreMockedApi(mockedApi: MockedApi): void {
+  mockedApi.forEach((mock) => mock.mockRestore());
+}


### PR DESCRIPTION
## Description

<!-- Link an issue to this PR. If none, this line can be removed -->
Closes #21 

#### Purpose / goal

<!-- What is the reason of this PR? -->

Substitute basic API key with access token as a more secure authentication method for API requests.

#### Key changes

<!-- List the specific changes to guide reviewers on what to look for. -->

- [x] Changed the `apiKey` parameter to a configuration object that is used by the library to fetch/refresh access tokens
- [x] Set the access token as the bearer token header value to authenticate OneSpan Sign API requests

## Checklists
<!-- Make sure the following steps, where applicable, have been completed. You may add more items to the checklist as needed. -->
- [x] Wrote unit tests
- [x] Updated API documentation

## References
https://www.onespan.com/blog/onespan-sign-release-1134-api-token-client-application